### PR TITLE
Add optional album parameter to Save to Photo Album action

### DIFF
--- a/language/standard/media.md
+++ b/language/standard/media.md
@@ -415,10 +415,10 @@ removeFromAlbum(variable photo, text album)
 
 ### Save to Photo Album
 
-Save `photo` to photo album `Recents`.
+Save `photo` to photo album `album`.
 
 ```
-savePhoto(variable photo)
+savePhoto(variable photo, text ?album = "Recents")
 ```
 
 ---


### PR DESCRIPTION
This PR adds an optional `album` parameter with the default value "Recents" to the [Save to Photo Album](https://cherrilang.org/language/standard/media.html#save-to-photo-album) action so that developers can use it to save photos to specific albums like the Shortcut app lets you do.

[Compiler PR](https://github.com/electrikmilk/cherri/pull/66)