### PR TITLE
Add missing URL encode and decode actions

### DIFF
--- a/language/standard/scripting.md
+++ b/language/standard/scripting.md
@@ -556,7 +556,7 @@ base64Decode(variable input)
 URL encodes `input`.
 
 ```
-urlEncode(variable input)
+urlEncode(text input)
 ```
 
 ---
@@ -566,7 +566,7 @@ urlEncode(variable input)
 URL decodes `input`.
 
 ```
-urlDecode(variable input)
+urlDecode(text input)
 ```
 
 ---

--- a/language/standard/scripting.md
+++ b/language/standard/scripting.md
@@ -551,6 +551,26 @@ base64Decode(variable input)
 
 ---
 
+### URL Encode
+
+URL encodes `input`.
+
+```
+urlEncode(variable input)
+```
+
+---
+
+### URL Decode
+
+URL decodes `input`.
+
+```
+urlDecode(variable input)
+```
+
+---
+
 ### Hash
 
 Generate a hash of `type` using `input`.


### PR DESCRIPTION
Hi, I noticed that the [`urlEncode`](https://github.com/electrikmilk/cherri/blob/731fa4627fa6069d448bce8233027900869059ff/actions_std.go#L3801) and [`urlDecode`](https://github.com/electrikmilk/cherri/blob/731fa4627fa6069d448bce8233027900869059ff/actions_std.go#L3820) actions are missing from the documentation, so I've added them.