### PR TITLE
Document Health actions

### DIFF
--- a/decompilation.md
+++ b/decompilation.md
@@ -45,16 +45,6 @@ Keep in mind this is mainly meant to be a starting point, and you may in some ca
 ## Standard Action Output
 
 When Cherri recognizes a standard action, import output uses the standard Cherri syntax instead of `rawAction(...)`.
-For example, a Shortcut that logs blood pressure to Health decompiles to:
-
-```ruby
-#include 'actions/health'
-
-const systolic = prompt("Systolic", "Number")
-const diastolic = prompt("Diastolic", "Number")
-
-logBloodPressure(qty(systolic, "mmHg"), qty(diastolic, "mmHg"))
-```
 
 If an action is not implemented in Cherri, import will keep it as a [raw action](/language/raw-actions).
 

--- a/decompilation.md
+++ b/decompilation.md
@@ -42,6 +42,22 @@ The import feature works best with an iCloud link, as decompiling signed Shortcu
 
 Keep in mind this is mainly meant to be a starting point, and you may in some cases need to do some modifications to get it working.
 
+## Standard Action Output
+
+When Cherri recognizes a standard action, import output uses the standard Cherri syntax instead of `rawAction(...)`.
+For example, a Shortcut that logs blood pressure to Health decompiles to:
+
+```ruby
+#include 'actions/health'
+
+const systolic = prompt("Systolic", "Number")
+const diastolic = prompt("Diastolic", "Number")
+
+logBloodPressure(qty(systolic, "mmHg"), qty(diastolic, "mmHg"))
+```
+
+If an action is not implemented in Cherri, import will keep it as a [raw action](/language/raw-actions).
+
 ### Caveats
 
 These two features are currently not supported in Cherri and so cannot be decompiled:

--- a/language/standard/health.md
+++ b/language/standard/health.md
@@ -62,7 +62,7 @@ logBloodPressure(qty(120, "mmHg"), qty(80, "mmHg"), CurrentDate)
 
 ---
 
-### Log Health Quantity
+### Log Health Quantity Sample
 
 Log a single quantity sample to Health.
 
@@ -135,7 +135,7 @@ enum healthQuantitySampleType {
     'Diastolic Blood Pressure',
 }
 
-logHealthQuantity(#healthQuantityUnit (qty)?quantity, healthQuantitySampleType sampleType, variable ?date)
+logHealthQuantitySample(#healthQuantityUnit (qty)?quantity, healthQuantitySampleType sampleType, variable ?date)
 ```
 
 **Example Usage**
@@ -143,16 +143,16 @@ logHealthQuantity(#healthQuantityUnit (qty)?quantity, healthQuantitySampleType s
 ```ruby
 #include 'actions/health'
 
-logHealthQuantity(qty(72, "count/min"), "Heart Rate")
-logHealthQuantity(qty(70, "kg"), "Body Mass")
-logHealthQuantity(qty(20, "count"), "Steps", CurrentDate)
+logHealthQuantitySample(qty(72, "count/min"), "Heart Rate")
+logHealthQuantitySample(qty(70, "kg"), "Body Mass")
+logHealthQuantitySample(qty(20, "count"), "Steps", CurrentDate)
 ```
 
 If you are logging blood pressure, prefer `logBloodPressure()` so the systolic and diastolic values are recorded together.
 
 ---
 
-### Log Health Category
+### Log Health Category Sample
 
 Log a category sample, such as a symptom, mindful session, or sleep analysis, to Health. The `value` and optional `additionalValue` strings map directly to Shortcuts' Health category picker values.
 
@@ -165,13 +165,13 @@ enum healthCategorySampleType {
     'Mindful Session',
 }
 
-logHealthCategory(healthCategorySampleType sampleType, text value, text ?additionalValue, variable ?startDate, variable ?endDate)
+logHealthCategorySample(healthCategorySampleType sampleType, text value, text ?additionalValue, variable ?startDate, variable ?endDate)
 ```
 
 **Example Usage**
 
 ```ruby
-logHealthCategory("Acne", "Present", nil, CurrentDate, CurrentDate)
+logHealthCategorySample("Acne", "Present", nil, CurrentDate, CurrentDate)
 ```
 
 ---
@@ -189,7 +189,7 @@ findHealthSamples(variable input): array
 ```ruby
 #include 'actions/health'
 
-const steps = logHealthQuantity(qty(20, "count"), "Steps", CurrentDate)
+const steps = logHealthQuantitySample(qty(20, "count"), "Steps", CurrentDate)
 findHealthSamples(steps)
 ```
 
@@ -208,7 +208,7 @@ getHealthSampleDetail(variable sample, text detail)
 ```ruby
 #include 'actions/health'
 
-const steps = logHealthQuantity(qty(20, "count"), "Steps", CurrentDate)
+const steps = logHealthQuantitySample(qty(20, "count"), "Steps", CurrentDate)
 getHealthSampleDetail(steps, "Value")
 ```
 

--- a/language/standard/health.md
+++ b/language/standard/health.md
@@ -1,0 +1,242 @@
+---
+title: Health
+layout: default
+grand_parent: Documentation
+parent: Actions
+nav_order: 8
+---
+
+# Health Actions
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+{: .note }
+> To use actions in this category, use this include statement:
+>
+> ```
+> #include 'actions/health'
+> ```
+
+Health quantity values use Cherri's `qty(value, "unit")` syntax. For example, a blood pressure reading uses `mmHg`:
+
+```ruby
+#include 'actions/health'
+
+const systolic = prompt("Systolic", "Number")
+const diastolic = prompt("Diastolic", "Number")
+
+logBloodPressure(qty(systolic, "mmHg"), qty(diastolic, "mmHg"))
+```
+
+The generated Shortcut writes the reading to Health using the Shortcuts Health sample action. The macOS HealthKit SDK used for validation exposes 120 quantity identifiers, 70 category identifiers, 2 correlation identifiers, and 84 workout activity types.
+
+## Samples
+
+### Log Blood Pressure
+
+Log systolic and diastolic blood pressure to Health.
+
+```
+enum bloodPressureUnit {
+    'mmHg',
+}
+
+logBloodPressure(#bloodPressureUnit (qty)?systolic, #bloodPressureUnit (qty)?diastolic, variable ?date)
+```
+
+**Example Usage**
+
+```ruby
+#include 'actions/health'
+
+logBloodPressure(qty(120, "mmHg"), qty(80, "mmHg"))
+logBloodPressure(qty(120, "mmHg"), qty(80, "mmHg"), CurrentDate)
+```
+
+---
+
+### Log Health Quantity
+
+Log a single quantity sample to Health.
+
+```
+enum healthQuantityUnit {
+    'count',
+    'count/min',
+    '%',
+    'kg',
+    'lb',
+    'g',
+    'mg',
+    'mg/dL',
+    'mg/dl',
+    'mmol/L',
+    'kcal',
+    'Cal',
+    'cal',
+    'L',
+    'mL',
+    'm',
+    'km',
+    'cm',
+    'mm',
+    's',
+    'ms',
+    'min',
+    'hr',
+    'd',
+    'degC',
+    'degF',
+    'S',
+    'W',
+    'Pa',
+    'kPa',
+    'atm',
+    'dBASPL',
+    'J',
+    'kJ',
+    'J/s',
+    'm/s',
+    'm/s^2',
+    'L/min',
+    'mL/(kg*min)',
+    'ml/(kg*min)',
+    'kcal/(kg*hr)',
+    'IU',
+    'appleEffortScore',
+    'mmHg',
+}
+
+enum healthQuantitySampleType {
+    'Steps',
+    'Walking + Running Distance',
+    'Walking Step Length',
+    'Walking Speed',
+    'Time In Daylight',
+    'Vertical Oscillation',
+    'Forced Expiratory Volume 1',
+    'Body Mass',
+    'Body Mass Index',
+    'Body Fat Percentage',
+    'Heart Rate',
+    'Oxygen Saturation',
+    'Respiratory Rate',
+    'Blood Glucose',
+    'Dietary Energy',
+    'Water',
+    'Systolic Blood Pressure',
+    'Diastolic Blood Pressure',
+}
+
+logHealthQuantity(#healthQuantityUnit (qty)?quantity, healthQuantitySampleType sampleType, variable ?date)
+```
+
+**Example Usage**
+
+```ruby
+#include 'actions/health'
+
+logHealthQuantity(qty(72, "count/min"), "Heart Rate")
+logHealthQuantity(qty(70, "kg"), "Body Mass")
+logHealthQuantity(qty(20, "count"), "Steps", CurrentDate)
+```
+
+If you are logging blood pressure, prefer `logBloodPressure()` so the systolic and diastolic values are recorded together.
+
+---
+
+### Log Health Category
+
+Log a category sample, such as a symptom, mindful session, or sleep analysis, to Health. The `value` and optional `additionalValue` strings map directly to Shortcuts' Health category picker values.
+
+```
+enum healthCategorySampleType {
+    'Bladder Incontinence',
+    'Constipation',
+    'Acne',
+    'Sleep Analysis',
+    'Mindful Session',
+}
+
+logHealthCategory(healthCategorySampleType sampleType, text value, text ?additionalValue, variable ?startDate, variable ?endDate)
+```
+
+**Example Usage**
+
+```ruby
+logHealthCategory("Acne", "Present", nil, CurrentDate, CurrentDate)
+```
+
+---
+
+### Find Health Samples
+
+Find quantity samples from Health.
+
+```
+findHealthSamples(variable input): array
+```
+
+**Example Usage**
+
+```ruby
+#include 'actions/health'
+
+const steps = logHealthQuantity(qty(20, "count"), "Steps", CurrentDate)
+findHealthSamples(steps)
+```
+
+---
+
+### Open Health View
+
+Open a Health category view. The identifier is Apple's Health target identifier, and the optional title and symbol are used by the Shortcuts action target payload.
+
+```
+openHealthView(text identifier, text ?title, text ?symbol)
+```
+
+**Example Usage**
+
+```ruby
+openHealthView("HKDisplayCategoryIdentifier_13", "Respiratory", "lungs.fill")
+```
+
+---
+
+### Open Health Data
+
+Open a Health data type.
+
+```
+openHealthData(text identifier, text ?title, text ?symbol)
+```
+
+**Example Usage**
+
+```ruby
+openHealthData("HKDisplayTypeIdentifierForcedVitalCapacity", "Forced Vital Capacity", "lungs.fill")
+```
+
+---
+
+### Log Workout
+
+Log a workout to Health.
+
+```
+logWorkout(text workoutType, #healthQuantityUnit (qty)?calories)
+```
+
+**Example Usage**
+
+```ruby
+logWorkout("Basketball", qty(500, "Cal"))
+```

--- a/language/standard/health.md
+++ b/language/standard/health.md
@@ -35,7 +35,7 @@ const diastolic = prompt("Diastolic", "Number")
 logBloodPressure(qty(systolic, "mmHg"), qty(diastolic, "mmHg"))
 ```
 
-The generated Shortcut writes the reading to Health using the Shortcuts Health sample action. The macOS HealthKit SDK used for validation exposes 120 quantity identifiers, 70 category identifiers, 2 correlation identifiers, and 84 workout activity types.
+The generated Shortcut writes the reading to Health using Shortcuts' Health actions. The macOS HealthKit SDK used for validation exposes 120 quantity identifiers, 70 category identifiers, 2 correlation identifiers, and 84 workout activity types. Cherri also supports the Health app navigation intents available in Shortcuts, including opening views, data types, categories, records, search, tabs, and the sleep schedule.
 
 ## Samples
 
@@ -195,6 +195,25 @@ findHealthSamples(steps)
 
 ---
 
+### Get Details of Health Sample
+
+Get a detail from a Health sample returned by a Health action.
+
+```
+getHealthSampleDetail(variable sample, text detail)
+```
+
+**Example Usage**
+
+```ruby
+#include 'actions/health'
+
+const steps = logHealthQuantity(qty(20, "count"), "Steps", CurrentDate)
+getHealthSampleDetail(steps, "Value")
+```
+
+---
+
 ### Open Health View
 
 Open a Health category view. The identifier is Apple's Health target identifier, and the optional title and symbol are used by the Shortcuts action target payload.
@@ -227,16 +246,118 @@ openHealthData("HKDisplayTypeIdentifierForcedVitalCapacity", "Forced Vital Capac
 
 ---
 
+### Open Health Category
+
+Open a Health category.
+
+```
+openHealthCategory(text identifier, text ?title, text ?symbol)
+```
+
+**Example Usage**
+
+```ruby
+openHealthCategory("HKDisplayCategoryIdentifier_13", "Respiratory", "lungs.fill")
+```
+
+---
+
+### Open Health Records
+
+Open a records section in Health.
+
+```
+openHealthRecords(text identifier, text ?title, text ?symbol)
+```
+
+**Example Usage**
+
+```ruby
+openHealthRecords("labs", "Lab Results", "cross.case.fill")
+```
+
+---
+
+### Search in Health
+
+Open Health and search for text.
+
+```
+openHealthSearch(text query)
+```
+
+**Example Usage**
+
+```ruby
+openHealthSearch("steps")
+```
+
+---
+
+### Open Sleep Schedule
+
+Open the sleep schedule in Health.
+
+```
+openSleepSchedule()
+openSleepScheduleLegacy()
+```
+
+**Example Usage**
+
+```ruby
+openSleepSchedule()
+```
+
+---
+
+### Open Health Tab
+
+Open a tab in Health.
+
+```
+openHealthTab(text identifier, text ?title, text ?symbol)
+```
+
+**Example Usage**
+
+```ruby
+openHealthTab("summary", "Summary", "heart.text.square")
+```
+
+---
+
 ### Log Workout
 
 Log a workout to Health.
 
 ```
-logWorkout(text workoutType, #healthQuantityUnit (qty)?calories)
+logWorkout(text workoutType, #healthQuantityUnit (qty)?calories, variable ?date, #healthQuantityUnit (qty)?duration, #healthQuantityUnit (qty)?distance)
 ```
 
 **Example Usage**
 
 ```ruby
 logWorkout("Basketball", qty(500, "Cal"))
+logWorkout("Basketball", qty(500, "Cal"), CurrentDate, qty(30, "min"), qty(1, "km"))
+```
+
+---
+
+## Activity
+
+### Get Physical Activity
+
+Get the current physical activity detected by the system.
+
+```
+getPhysicalActivity(): text
+```
+
+The result is one of `Unknown`, `Stationary`, `Walking`, `Running`, `Cycling`, `In a Stationary Vehicle`, `In a Moving Vehicle`, or `Moving`.
+
+**Example Usage**
+
+```ruby
+getPhysicalActivity()
 ```


### PR DESCRIPTION
This PR adds documentation for the Health standard actions added in the related compiler PR.

It covers logging quantity samples with `logHealthQuantitySample`, logging category samples with `logHealthCategorySample`, blood pressure, workouts, finding Health samples, reading sample details, opening Health views, data types, categories, records, search, tabs, sleep schedule, and getting physical activity. It also shows the `qty(value, "unit")` syntax used for Health quantity values.

The Health type coverage was checked against the local macOS HealthKit SDK, which exposes 120 quantity identifiers, 70 category identifiers, 2 correlation identifiers, and 84 workout activity types.

[Compiler PR](https://github.com/electrikmilk/cherri/pull/192)
